### PR TITLE
Enable MacOS ARM64 builds with FlyCI's runners.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: install ninja (osx)
       run: brew install ninja
-      if: matrix.os == 'macos-12'
+      if: matrix.os == 'macos-12' || matrix.os == 'flyci-macos-large-latest-m1'
     - name: install ninja (win)
       run: choco install ninja
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest, flyci-macos-large-latest-m1]
     steps:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
+        architecture: ${{ (matrix.os == 'flyci-macos-large-latest-m1' && 'arm64') || 'x64' }}
     - uses: actions/checkout@v1
       with:
         submodules: true


### PR DESCRIPTION

Add MacOS ARM64 support using FlyCI's MacOS runners: 
[#2366](https://github.com/WebAssembly/wabt/issues/2366)

